### PR TITLE
Change Logic output type to Boolean output type

### DIFF
--- a/procedures/README.md
+++ b/procedures/README.md
@@ -90,7 +90,7 @@ Has the same structure as procedural procedure block, but needs to have Blockly 
 
 Output type needs to be in blockly format, for example:
 * Number
-* Logic
+* Boolean
 * String
 * MCItem
 * MCItemBlock


### PR DESCRIPTION
I just find that the README said *Logic* instead of *Boolean* for the output type, so I changed it.